### PR TITLE
Fix compiling on ESP Arduino core 2.0.x

### DIFF
--- a/src/btAudio.cpp
+++ b/src/btAudio.cpp
@@ -51,13 +51,12 @@ void btAudio::begin() {
   esp_a2d_register_callback(a2d_cb);
   
   // set discoverable and connectable mode, wait to be connected
-#if defined ESP_BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE
-  // Old (1.x) ESP arduino core
-  esp_bt_gap_set_scan_mode(ESP_BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE);
-#else
-  // ESP arduino core 2.x
+#if ESP_IDF_VERSION_MAJOR > 3
   esp_bt_gap_set_scan_mode(ESP_BT_CONNECTABLE, ESP_BT_GENERAL_DISCOVERABLE);
+#else
+  esp_bt_gap_set_scan_mode(ESP_BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE);
 #endif
+
 }
 void btAudio::end() {
   esp_a2d_sink_deinit();
@@ -167,12 +166,10 @@ void btAudio::I2S(int bck, int dout, int ws) {
     .sample_rate = _sampleRate,
     .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
     .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
-#if defined I2S_COMM_FORMAT_I2S
-    // Old (1.x) ESP arduino core
-    .communication_format = static_cast<i2s_comm_format_t>(I2S_COMM_FORMAT_I2S|I2S_COMM_FORMAT_I2S_MSB),
-#else
-     // ESP arduino core 2.x
+#if ESP_IDF_VERSION_MAJOR > 3
     .communication_format = static_cast<i2s_comm_format_t>(I2S_COMM_FORMAT_STAND_I2S|I2S_COMM_FORMAT_STAND_MSB),
+#else
+    .communication_format = static_cast<i2s_comm_format_t>(I2S_COMM_FORMAT_I2S|I2S_COMM_FORMAT_I2S_MSB),
 #endif
     .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1, // default interrupt priority
     .dma_buf_count = 3,

--- a/src/btAudio.cpp
+++ b/src/btAudio.cpp
@@ -4,7 +4,7 @@
 ////////////////////////////////////////////////////////////////////
  float btAudio::_vol=0.95;
  uint8_t btAudio::_address[6];
- uint32_t btAudio::_sampleRate=44100;
+ int32_t btAudio::_sampleRate=44100;
   
  String btAudio::title="";
  String btAudio::album="";
@@ -51,7 +51,7 @@ void btAudio::begin() {
   esp_a2d_register_callback(a2d_cb);
   
   // set discoverable and connectable mode, wait to be connected
-  esp_bt_gap_set_scan_mode(ESP_BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE);  	
+  esp_bt_gap_set_scan_mode(ESP_BT_CONNECTABLE, ESP_BT_GENERAL_DISCOVERABLE);
 }
 void btAudio::end() {
   esp_a2d_sink_deinit();
@@ -161,7 +161,7 @@ void btAudio::I2S(int bck, int dout, int ws) {
     .sample_rate = _sampleRate,
     .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
     .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
-    .communication_format = static_cast<i2s_comm_format_t>(I2S_COMM_FORMAT_I2S|I2S_COMM_FORMAT_I2S_MSB),
+    .communication_format = static_cast<i2s_comm_format_t>(I2S_COMM_FORMAT_STAND_I2S|I2S_COMM_FORMAT_STAND_MSB),
     .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1, // default interrupt priority
     .dma_buf_count = 3,
     .dma_buf_len = 600,

--- a/src/btAudio.cpp
+++ b/src/btAudio.cpp
@@ -51,7 +51,13 @@ void btAudio::begin() {
   esp_a2d_register_callback(a2d_cb);
   
   // set discoverable and connectable mode, wait to be connected
+#if defined ESP_BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE
+  // Old (1.x) ESP arduino core
+  esp_bt_gap_set_scan_mode(ESP_BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE);
+#else
+  // ESP arduino core 2.x
   esp_bt_gap_set_scan_mode(ESP_BT_CONNECTABLE, ESP_BT_GENERAL_DISCOVERABLE);
+#endif
 }
 void btAudio::end() {
   esp_a2d_sink_deinit();
@@ -161,7 +167,13 @@ void btAudio::I2S(int bck, int dout, int ws) {
     .sample_rate = _sampleRate,
     .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
     .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
+#if defined I2S_COMM_FORMAT_I2S
+    // Old (1.x) ESP arduino core
+    .communication_format = static_cast<i2s_comm_format_t>(I2S_COMM_FORMAT_I2S|I2S_COMM_FORMAT_I2S_MSB),
+#else
+     // ESP arduino core 2.x
     .communication_format = static_cast<i2s_comm_format_t>(I2S_COMM_FORMAT_STAND_I2S|I2S_COMM_FORMAT_STAND_MSB),
+#endif
     .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1, // default interrupt priority
     .dma_buf_count = 3,
     .dma_buf_len = 600,

--- a/src/btAudio.h
+++ b/src/btAudio.h
@@ -60,7 +60,7 @@ class btAudio {
     const char *_devName;
 	bool _filtering=false;
 	bool _compressing=false;
-    static uint32_t  _sampleRate;
+    static int32_t  _sampleRate;
 	static int _postprocess;
 	
 	// static function causes a static infection of variables


### PR DESCRIPTION
This fixes compiling on the ESP Arduino Core 2.0.1 (current) for all the examples, and my sketch based off of those examples now compiles and runs correctly with the latest ESP release.

#### TL;DR
The first error was due to ESP expanding and separating discoverability vs connectability
```
[exec] /home/user/Arduino/libraries/btAudio/src/btAudio.cpp: In member function 'void btAudio::begin()':
[exec] /home/user/Arduino/libraries/btAudio/src/btAudio.cpp:54:28: error: 'ESP_BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE' was not declared in this scope
[exec]    esp_bt_gap_set_scan_mode(ESP_BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE);
[exec]                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[exec] /home/user/Arduino/libraries/btAudio/src/btAudio.cpp:54:28: note: suggested alternative: 'ESP_BT_GENERAL_DISCOVERABLE'
[exec]    esp_bt_gap_set_scan_mode(ESP_BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE);
[exec]                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[exec]                             ESP_BT_GENERAL_DISCOVERABLE
```
I fixed this by copying the modified ESP examples, using two separate defines for discoverability + connectability.

The second seems to be a renaming of the comms format defines,  fixed by following the depreciation warning and suggestion.
```
[exec] /home/user/Arduino/libraries/btAudio/src/btAudio.cpp: In member function 'void btAudio::I2S(int, int, int)':
[exec] /home/user/Arduino/libraries/btAudio/src/btAudio.cpp:164:60: warning: 'I2S_COMM_FORMAT_I2S' is deprecated [-Wdeprecated-declarations]
[exec]      .communication_format = static_cast<i2s_comm_format_t>(I2S_COMM_FORMAT_I2S|I2S_COMM_FORMAT_I2S_MSB),
[exec]                                                             ^~~~~~~~~~~~~~~~~~~
[exec] In file included from /home/user/.arduino15/packages/esp32/hardware/esp32/2.0.0/tools/sdk/esp32/include/hal/esp32/include/hal/i2s_ll.h:30,
[exec]                  from /home/user/.arduino15/packages/esp32/hardware/esp32/2.0.0/tools/sdk/esp32/include/hal/include/hal/i2s_hal.h:28,
[exec]                  from /home/user/.arduino15/packages/esp32/hardware/esp32/2.0.0/tools/sdk/esp32/include/driver/include/driver/i2s.h:16,
[exec]                  from /home/user/Arduino/libraries/btAudio/src/btAudio.h:10,
[exec]                  from /home/user/Arduino/libraries/btAudio/src/btAudio.cpp:1:
[exec] /home/user/.arduino15/packages/esp32/hardware/esp32/2.0.0/tools/sdk/esp32/include/hal/include/hal/i2s_types.h:70:5: note: declared here
[exec]      I2S_COMM_FORMAT_I2S       __attribute__((deprecated)) = 0x01, /*!< I2S communication format I2S, correspond to `I2S_COMM_FORMAT_STAND_I2S`*/
[exec]      ^~~~~~~~~~~~~~~~~~~
[exec] /home/user/Arduino/libraries/btAudio/src/btAudio.cpp:164:80: warning: 'I2S_COMM_FORMAT_I2S_MSB' is deprecated [-Wdeprecated-declarations]
[exec]      .communication_format = static_cast<i2s_comm_format_t>(I2S_COMM_FORMAT_I2S|I2S_COMM_FORMAT_I2S_MSB),
[exec]                                                                                 ^~~~~~~~~~~~~~~~~~~~~~~
[exec] In file included from /home/user/.arduino15/packages/esp32/hardware/esp32/2.0.0/tools/sdk/esp32/include/hal/esp32/include/hal/i2s_ll.h:30,
[exec]                  from /home/user/.arduino15/packages/esp32/hardware/esp32/2.0.0/tools/sdk/esp32/include/hal/include/hal/i2s_hal.h:28,
[exec]                  from /home/user/.arduino15/packages/esp32/hardware/esp32/2.0.0/tools/sdk/esp32/include/driver/include/driver/i2s.h:16,
[exec]                  from /home/user/Arduino/libraries/btAudio/src/btAudio.h:10,
[exec]                  from /home/user/Arduino/libraries/btAudio/src/btAudio.cpp:1:
[exec] /home/user/.arduino15/packages/esp32/hardware/esp32/2.0.0/tools/sdk/esp32/include/hal/include/hal/i2s_types.h:71:5: note: declared here
[exec]      I2S_COMM_FORMAT_I2S_MSB   __attribute__((deprecated)) = 0x01, /*!< I2S format MSB, (I2S_COMM_FORMAT_I2S |I2S_COMM_FORMAT_I2S_MSB) correspond to `I2S_COMM_FORMAT_STAND_I2S`*/
[exec]      ^~~~~~~~~~~~~~~~~~~~~~~
```
Finally there was a non-fatal warning.
```
[exec] /home/user/Arduino/libraries/btAudio/src/btAudio.cpp:170:3: warning: narrowing conversion of 'btAudio::_sampleRate' from 'uint32_t' {aka 'unsigned int'} to 'int' inside { } [-Wnarrowing]
[exec]    };
[exec]    ^
[exec] exit status 1
[exec] Error compiling for board TTGO T-Watch.
```
I 'fixed' this by changing the `sampleRate` type to a *signed* integer, which I assume matches a change upstream. But didnt investigate too much so this should be reviewed/checked as to whether it is the correct solution.