### PR TITLE
Auto-reconnect to last connected Bluetooth device

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ The code exposes the A2DP profile (Bluetooth Audio) available in ESP32 boards us
 	1. [DRC: Partial Control](#h1)
 	2. [DRC: Full Control](#h2)
 	3. [DRC: Approximation](#h3)
-9. [Wifi Interface](#i)
+9. [WiFi Interface](#i)
 	
 [Appendix I: Not so simple audio](#app)
 
 
 <a name="a"></a>
 ## Installation
-1. [Install the arduino IDE](https://www.arduino.cc/en/main/software)
-2. [Install the esp32 core for arduino](https://docs.espressif.com/projects/arduino-esp32/en/latest/installing.html)
+1. [Install the Arduino IDE](https://www.arduino.cc/en/main/software)
+2. [Install the ESP32 core for Arduino](https://docs.espressif.com/projects/arduino-esp32/en/latest/installing.html)
 3. [Download this repository](https://github.com/tierneytim/btAudio/archive/refs/heads/master.zip)
 <p align="center">
   <img src="readme/download.png" width="600" />
@@ -34,25 +34,26 @@ The code exposes the A2DP profile (Bluetooth Audio) available in ESP32 boards us
 <p align="center">
   <img src="readme/includeLibrary.png" width="450" />
 </p>
-This should add the library. To use the library, you'll have to include the relevant header in the arduino sketch. You'll see this in the following sketches.
+This should add the library. To use the library, you'll have to include the relevant header in the Arduino sketch. You'll see this in the following sketches.
 
 <a name="b"></a>
 ## Advertising the Connection
 This section covers the [advertiseBluetooth](examples/advertiseBluetooth/advertiseBluetooth.ino) example.
-The first step to getting some bluetooth audio up and running is to advertise your ESP32 board.  You will need to include the btAudio header and declare a `btAudio` object.
+The first step to getting some Bluetooth audio up and running is to advertise your ESP32 board.  You will need to include the btAudio header and declare a `btAudio` object.
+
 ```cpp
 #include <btAudio.h>
 
 // Sets the name of the audio device
 btAudio audio = btAudio("ESP_Speaker");
 ```
-The string that you supply to the `btAudio` object becomes the name of the ESP32 bluetooth connection. However, this only initialises the object. It doesn't actually start the bluetooth. For that you'll need to use the `btAudio::begin` method.
- 
+
+The string that you supply to the `btAudio` object becomes the name of the ESP32 Bluetooth connection. However, this only initialises the object. It doesn't actually start the Bluetooth. For that you'll need to use the `btAudio::begin` method.
  
 ```cpp
 void setup() {
  
- // streams audio data to the ESP32   
+ // Streams audio data to the ESP32   
  audio.begin();
 
 }
@@ -62,7 +63,27 @@ void loop() {
 }
 ```
 
-Yay, now you can connect to your ESP32 board and stream audio to it.  You can connect with your phone, laptop, MP3 player, whatever you want. Sadly, this data is stuck on the ESP32 unless you have a DAC (Digital to Analogue Converter) that can actually send the audio somewhere (speaker, Hi-Fi system). I'll cover that in the next section. Anywho the whole script is below.
+Yay, now you can connect to your ESP32 board and stream audio to it.  You can connect with your phone, laptop, MP3 player, whatever you want. Sadly, this data is stuck on the ESP32 unless you have a DAC (Digital to Analogue Converter) that can actually send the audio somewhere (speaker, Hi-Fi system). I'll cover that in the next section.
+
+btAudio can remember and attempt to automatically connect to the last connected source device.  Just call the `audio.reconnect()`  function, and btAudio will connect to the last remembered device.  You can also manually disconnect from the current source device using the `audio.disconnect()` function.
+
+```cpp
+void setup() {
+ 
+ // Streams audio data to the ESP32   
+ audio.begin();
+ 
+ // Re-connects to last connected device
+ audio.reconnect();
+
+}
+
+void loop() {
+
+}
+```
+
+The whole script is below:
 
 ```cpp
 #include <btAudio.h>
@@ -72,8 +93,11 @@ btAudio audio = btAudio("ESP_Speaker");
 
 void setup() {
  
- // streams audio data to the ESP32   
+ // Streams audio data to the ESP32   
  audio.begin();
+ 
+ // Re-connects to last connected device
+ audio.reconnect();
 
 }
 
@@ -81,13 +105,11 @@ void loop() {
 
 }
 ```
-
-Note that btAudio will remember and attempt to automatically connect to the last connected source device when `audio.begin()` is first called.  Also, if you need, you can manually disconnect or re-connect to the source device using the `audio.disconnect()` and `audio.reconnect()` functions.
 
 <a name="c"></a>
 ## Simple Audio
 This section covers the [minimalAudio](examples/minimalAudio/minimalAudio.ino) example.
-Now that we have mastered the bluetooth component of "Bluetooth Audio" let's turn to the audio part. This requires some extra hardware. I like the adafruit [I2S Stereo decoder](https://www.adafruit.com/product/3678). It takes data from the ESP32 and converts it to a line out signal  which can be plugged into a stereo or Hi-Fi system (instantly adding wireless audio to your audio system). But what is I2S and what extra hardware do you need?
+Now that we have mastered the Bluetooth component of "Bluetooth Audio", let's turn to the audio part. This requires some extra hardware. I like the Adafruit [I2S Stereo decoder](https://www.adafruit.com/product/3678). It takes data from the ESP32 and converts it to a line out signal which can be plugged into a stereo or Hi-Fi system (instantly adding wireless audio to your audio system). But what is I2S and what extra hardware do you need?
 
 <a name="c1"></a>
 ### Hardware: Components
@@ -126,6 +148,8 @@ My setup looks like this.
 ### I2S
 [I2S](https://www.arduino.cc/en/Reference/I2S) is method of digitally transferring audio data between devices. It uses just 3 wires. This is particularly useful in transferring data to an external high performance Digital to Analog Converter (DAC). For instance most ESP32s have 2 8-bit DACs whereas music is usually played over 16-bit DACs (or better). However, you can get cheap 16 bit DACs that you can plug into your speakers/Hi-Fi systems. These DACs receive data from your microcontroller using I2S. The one I have been using is the Adafruit [I2S Stereo decoder](https://www.adafruit.com/product/3678). Not all microcontrollers have I2S communication and Bluetooth Classic/ WIFI. This is why the ESP32 boards are key here. They have both. A simple bit of code to combine both the bluetooth and the I2S is given below. The only difference between this code and the advertising code is calling the `btAudio::I2S` method and specifying the 3 pins that you want to use. A cool feature about ESP32s is that you usually pick whatever pins to do whatever action you want. So feel free to change the pins.
 
+The full contents of the `minimalAudio` example are below.
+
 ```cpp
 #include <btAudio.h>
 
@@ -134,10 +158,13 @@ btAudio audio = btAudio("ESP_Speaker");
 
 void setup() {
  
- // streams audio data to the ESP32   
+ // Streams audio data to the ESP32   
  audio.begin();
  
- //  outputs the received data to an I2S DAC https://www.adafruit.com/product/3678
+ // Re-connects to last connected device
+ audio.reconnect();
+ 
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;
@@ -161,11 +188,14 @@ Volume is a tricky issue. Ideally, the sender should issue a request for volume 
 btAudio audio = btAudio("ESP_Speaker");
 
 void setup() {
- 
- // streams audio data to the ESP32   
+
+ // Streams audio data to the ESP32   
  audio.begin();
- 
- //  outputs the received data to an I2S DAC https://www.adafruit.com/product/3678
+
+ // Re-connects to last connected device
+ audio.reconnect();
+
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;
@@ -173,12 +203,13 @@ void setup() {
 }
 
 void loop() {
-delay(3000);
-audio.volume(0.1);
-delay(3000);
-audio.volume(1.0);
+  delay(3000);
+  audio.volume(0.1);
+  delay(3000);
+  audio.volume(1.0);
 }
 ```
+
 <a name="e"></a>
 ## Serial Control
 This section covers the [serialControl](examples/serialControl/serialControl.ino) example.
@@ -188,7 +219,8 @@ If you want to control any of the features proposed here you may need to create 
   <img src="readme/serial.PNG" width="600" />
 </p> 
 
- Once the code in the next section is uploaded try and experiment by opening the serial monitor and changing the volume a bit. This general approach can be adpated for any method. 
+Once the code in the next section is uploaded try and experiment by opening the serial monitor and changing the volume a bit. This general approach can be adapted for any method.
+
 ```cpp
 #include <btAudio.h>
 
@@ -196,12 +228,16 @@ btAudio audio = btAudio("ESP_Speaker");
 String command;
 
 void setup() { 
+ // Streams audio data to the ESP32   
  audio.begin();
+ // Re-connects to last connected device
+ audio.reconnect();
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;
  audio.I2S(bck, dout, ws);
- // open the serial port
+ // Opens the serial port
  Serial.begin(115200);
 }
 
@@ -227,6 +263,7 @@ void loop() {
 This section covers the [highpassFilter](examples/highpassFilter/highpassFilter.ino) example.
 High-Pass filters remove low frequency content from your data. You can either set the parameters in the `void setup()` section or you can interactively edit the parameters via the serial interface. The method is `btAudio::createFilter`. The implementation uses a cascade of [biquad filters](https://www.earlevel.com/main/2012/11/26/biquad-c-source-code/).
 The method takes three arguments. The first specifies the number of filter cascades. A higher number makes the filter sharper but increases the run-time of the method. For me a value of 3 is a good compromise between computation time and filter efficacy. The second argument is the filter cutoff. Below this frequency the signal starts to get suppressed. The third argument is the filter type. Setting the value to `highpass` makes the filter a high-pass filter. Calling the `stopFilter()` method stops the effects of the filter(send command `stopFilt#`). Experiment with a few values for your high pass cut off. Most speakers struggle to produce sound below 100Hz so sending the command `hp#100` should only make a very small difference to your listening. Send the command `hp#600` and you will notice a very big difference! The sound will sound like it's coming through a very old phone...
+
 ```cpp
 #include <btAudio.h>
 
@@ -234,14 +271,18 @@ btAudio audio = btAudio("ESP_Speaker");
 String command;
 
 void setup() { 
+ // Streams audio data to the ESP32   
  audio.begin();
+ // Re-connects to last connected device
+ audio.reconnect();
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;
  audio.I2S(bck, dout, ws);
+ // Opens the serial port
  Serial.begin(115200);
 }
-
 
 int fo=3;
 float fc=30;
@@ -261,7 +302,6 @@ void loop() {
   }   
  }
 }
-
 ```
 
 <a name="g"></a>
@@ -275,14 +315,18 @@ btAudio audio = btAudio("ESP_Speaker");
 String command;
 
 void setup() { 
+ // Streams audio data to the ESP32   
  audio.begin();
+ // Re-connects to last connected device
+ audio.reconnect();
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;
  audio.I2S(bck, dout, ws);
+ // Opens the serial port
  Serial.begin(115200);
 }
-
 
 int fo=3;
 float fc;
@@ -307,7 +351,6 @@ void loop() {
   }  
  }
 }
-
 ```
 <a name="h"></a>
 ## Dynamic Range Compression
@@ -316,11 +359,10 @@ I'll highlight terms throughout this section that will be parameters for the [Dy
 
 You can also specify the `width` of this soft knee (i.e. How gradual you want the compression to be). Setting this `width` to zero implements a hard knee. You can also set `attack` and `release` times. These are time constants that determine how quickly the compressor starts working. For instance if there was a sudden change in volume you might want to have a very quick `attack` time so as to compress that signal quickly. Having a long `release` time will leave the compressor running for a brief time after it has started compressing. I've got two examples on how to use the compressor. One has extreme parameters that you can just turn on or off and another with full serial control over all the parameters. 
 
-
 <a name="h1"></a>
 ### DRC: Partial Control
 This section covers the [partialDRC](examples/partialDRC/partialDRC.ino) example. 
-For turning the compressor on and off just send the `compress#` and `decompress#` commands over the serial port. This will call the `btAudio::compress` method and the `btAudio::decompress` method. Hopefully, you should hear a clear difference between compressed and uncompressed data. It can be quite useful for making sure audio will never clip a set of speakers and for watching tv shows that have very loud background music and very low vocals. I'm looking at you xxxxxxx! 
+For turning the compressor on and off just send the `compress#` and `decompress#` commands over the serial port. This will call the `btAudio::compress` method and the `btAudio::decompress` method. Hopefully, you should hear a clear difference between compressed and uncompressed data. It can be quite useful for making sure audio will never clip a set of speakers and for watching TV shows that have very loud background music and very low vocals. I'm looking at you xxxxxxx! 
 ```cpp
 #include <btAudio.h>
 
@@ -328,13 +370,17 @@ btAudio audio = btAudio("ESP_Speaker");
 String command;
 
 void setup() { 
+ // Streams audio data to the ESP32   
  audio.begin();
+ // Re-connects to last connected device
+ audio.reconnect();
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;
  audio.I2S(bck, dout, ws);
+ // Opens the serial port
  Serial.begin(115200);
- 
 }
 
 float thresh=30;
@@ -381,11 +427,16 @@ btAudio audio = btAudio("ESP_Speaker");
 String command;
 
 void setup() { 
+ // Streams audio data to the ESP32   
  audio.begin();
+ // Re-connects to last connected device
+ audio.reconnect();
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;
  audio.I2S(bck, dout, ws);
+ // Opens the serial port
  Serial.begin(115200);
 }
 
@@ -441,11 +492,10 @@ void loop() {
    }
   }
 }
-
 ```
 <a name="h3"></a>
 ## Approximate Dynamic Range Compression
-Dynamic Range Compression is very computationaly expensive. I found for my esp32 the big stress was converting the computed gain (dB) back to a 16 bit integer. This required computing `pow10f(x/20)` which became a severe bottleneck. This operation took takes about 5 microseconds to compute. For a stereo system that's 10 microseconds. Considering there is only 11.3 microseconds between stereo samples using 10 microseconds for one line of code is abhorrent. 
+Dynamic Range Compression is very computationally expensive. I found for my ESP32 the big stress was converting the computed gain (dB) back to a 16 bit integer. This required computing `pow10f(x/20)` which became a severe bottleneck. This operation took takes about 5 microseconds to compute. For a stereo system that's 10 microseconds. Considering there is only 11.3 microseconds between stereo samples using 10 microseconds for one line of code is abhorrent. 
 <br>
 I thought about precomputing the values and creating a lookup table but that would require > 130KB of memory. That would not be the polite thing to do. Program storage space is valuable, particularly as the ESP32 uses a lot of memory for WIFI and Bluetooth. The compromise was to use a lookup table for integral part of `x` and a polynomial approximation for the fractional part of `x`. As `x` only ranges between -90dB and 90dB for signed 16 bit integers we can create a lookup table for the integral part using less than 400 bytes. For the fractional part we use [Newton's Divided Difference](https://en.wikipedia.org/wiki/Newton_polynomial) method for polynomial interpolation between the integer parts. Long story short this method has an accuracy of 0.01% and runs in 0.2 microseconds.  If you just use the integer lookup method the error is greater than 10% and takes 0.1 microseconds. In my opinion the extra 0.1 microseconds is worth the 1000 fold increase in accuracy. The code below is covered in the [benchLookup](examples/benchLookup/benchLookup.ino) example. This example isn't crucial but useful if you want to see the difference in methodologies.
 
@@ -560,9 +610,9 @@ If you run the above code you should get results like this on the serial monitor
 </p> 
 
 <a name="i"></a>
-## Wifi interface
+## WiFi interface
 This section covers the [webInterface example](examples/webInterface/webInterface.ino)
-The serial interface is useful for debugging but not very useful if you have the esp32 hooked up behind a speaker. To edit the DSP parameters wirelessly I've created a very simple web server that you can access via any browser connected to the same network as the ESP32. It's pretty straightforward to use. Simply create a `webDSP` object and pass it your SSID, internet password and the `btAudio` object.
+The serial interface is useful for debugging but not very useful if you have the ESP32 hooked up behind a speaker. To edit the DSP parameters wirelessly I've created a very simple web server that you can access via any browser connected to the same network as the ESP32. It's pretty straightforward to use. Simply create a `webDSP` object and pass it your SSID, password, and the `btAudio` object.
 
 ```cpp
 #include<webDSP.h>
@@ -575,31 +625,31 @@ btAudio audio = btAudio("ESP_Speaker");
 webDSP web;
 
 void setup() {
-  Serial.begin(115200);  
+ // Streams audio data to the ESP32   
+ audio.begin();
+ // Re-connects to last connected device
+ audio.reconnect();
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
+ int bck = 26; 
+ int ws = 27;
+ int dout = 25;
+ audio.I2S(bck, dout, ws);
+ // Opens the serial port
+ Serial.begin(115200);
   
-  //start streaming audio
-  audio.begin();
-  
-  //transmit data to DAC
-  int bck = 26; 
-  int ws = 27;
-  int dout = 25;  
-  audio.I2S(bck, dout, ws);
-  
-  // replace ssid and password with your details
-  const char* ssid = "";
-  const char* password = "";
-  web.begin(ssid,password ,&audio); 
+ // Replace ssid and password with your details
+ const char* ssid = "";
+ const char* password = "";
+ web.begin(ssid, password, &audio); 
 }
 
 void loop() {
   // continually check on client 
   web._server.handleClient();
 }
-
 ```
 
- The first time you run this bit of code you should have the serial monitor open so that you can see what the IP address assigned to your ESP32 is. Once you know this number simply enter it in to your browser and you'll be greeted by this webpage!
+The first time you run this bit of code, you should have the serial monitor open so that you can see what the IP address assigned to your ESP32 is. Once you know this number, simply enter it in to your browser and you'll be greeted by this webpage!
 
 <p align="center">
   <img src="readme/webpage.PNG" width="600" />
@@ -607,15 +657,13 @@ void loop() {
 
 You can expand each of the three sections and edit any of the parameters of the filters, volume or dynamic range compression. 
 
-
-
 <a name="app"></a>
 ## Not so simple audio
 What if [you hate classes/Object Oriented Programming](https://medium.com/better-programming/object-oriented-programming-the-trillion-dollar-disaster-92a4b666c7c7 ) and don't want to use my code but still want Bluetooth audio. Well this section covers just how to do that with the [underTheHood](examples/underTheHood/underTheHood.ino) example. It uses the minimum amount of ESP32 code to get audio output on I2S. I ain't gonna explain this. The reason I wrote the library is so that I wouldn't have to explain low level ESP32 code. However, for developers it may be easier to work with the raw ESP32 code as you can see the all the moving parts and dependencies more easily. However, for an end user(not a developer) I think a class based approach that hides these details is the way to go. Whatever your thoughts, I think I'm unlikely to shift from the object-oriented programming to more functional programming for this library. 
 
 On a technical note this code adapts the [ESP-IDF A2DP Sink](https://github.com/espressif/esp-idf/blob/master/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/main/main.c
-) example but uses the [arduino-esp32 library](https://github.com/espressif/arduino-esp32) . There are very subtle differences between these libraries. So this example will only work with the arduino library, not the ESP-IDF library. You'll need to use the much more complicated [ESP-IDF example](https://github.com/espressif/esp-idf/blob/master/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/main/main.c
-) if you work outside the arduino environment. 
+) example but uses the [arduino-esp32 library](https://github.com/espressif/arduino-esp32) . There are very subtle differences between these libraries. So this example will only work with the Arduino library, not the ESP-IDF library. You'll need to use the much more complicated [ESP-IDF example](https://github.com/espressif/esp-idf/blob/master/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/main/main.c
+) if you work outside the Arduino environment. 
 
 ```cpp
 // cricial audio bits taken from https://github.com/espressif/esp-idf/blob/master/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/main/main.c

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ void loop() {
 }
 ```
 
-Yay, now you can connect to your esp32 board and stream audio to it.  You can connect with your phone, laptop, MP3 player, whatever you want. Sadly, this data is stuck on the ESP32 unless you have a DAC (Digital to Analogue Converter) that can actually send the audio somewhere (speaker, Hi-Fi system). I'll cover that in the next section. Anywho the whole script is below.
+Yay, now you can connect to your ESP32 board and stream audio to it.  You can connect with your phone, laptop, MP3 player, whatever you want. Sadly, this data is stuck on the ESP32 unless you have a DAC (Digital to Analogue Converter) that can actually send the audio somewhere (speaker, Hi-Fi system). I'll cover that in the next section. Anywho the whole script is below.
 
 ```cpp
 #include <btAudio.h>
@@ -81,6 +81,9 @@ void loop() {
 
 }
 ```
+
+Note that btAudio will remember and attempt to automatically connect to the last connected source device when `audio.begin()` is first called.  Also, if you need, you can manually disconnect or re-connect to the source device using the `audio.disconnect()` and `audio.reconnect()` functions.
+
 <a name="c"></a>
 ## Simple Audio
 This section covers the [minimalAudio](examples/minimalAudio/minimalAudio.ino) example.

--- a/examples/advertiseBluetooth/advertiseBluetooth.ino
+++ b/examples/advertiseBluetooth/advertiseBluetooth.ino
@@ -5,8 +5,11 @@ btAudio audio = btAudio("ESP_Speaker");
 
 void setup() {
  
- // streams audio data to the ESP32   
+ // Streams audio data to the ESP32   
  audio.begin();
+ 
+ // Re-connects to last connected device
+ audio.reconnect();
 
 }
 

--- a/examples/allFeatures/allFeatures.ino
+++ b/examples/allFeatures/allFeatures.ino
@@ -4,11 +4,20 @@ btAudio audio = btAudio("ESP_Speaker");
 String command;
 
 void setup() { 
+
+ // Streams audio data to the ESP32   
  audio.begin();
+
+ // Re-connects to last connected device
+ audio.reconnect();
+
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;
  audio.I2S(bck, dout, ws);
+
+ // Opens the serial port
  Serial.begin(115200);
 }
 

--- a/examples/changeVolume/changeVolume.ino
+++ b/examples/changeVolume/changeVolume.ino
@@ -4,11 +4,14 @@
 btAudio audio = btAudio("ESP_Speaker");
 
 void setup() {
- 
- // streams audio data to the ESP32   
+
+ // Streams audio data to the ESP32   
  audio.begin();
- 
- //  outputs the received data to an I2S DAC https://www.adafruit.com/product/3678
+
+ // Re-connects to last connected device
+ audio.reconnect();
+
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;
@@ -16,8 +19,8 @@ void setup() {
 }
 
 void loop() {
-delay(3000);
-audio.volume(0.1);
-delay(3000);
-audio.volume(1.0);
+  delay(3000);
+  audio.volume(0.1);
+  delay(3000);
+  audio.volume(1.0);
 }

--- a/examples/customCallbacks/customCallbacks.ino
+++ b/examples/customCallbacks/customCallbacks.ino
@@ -62,11 +62,14 @@ void bt_data_cb2(const uint8_t *data, uint32_t len){
 }
 
 void setup() {
- 
- // streams audio data to the ESP32   
+
+ // Streams audio data to the ESP32   
  audio.begin();
- 
- //  outputs the received data to an I2S DAC https://www.adafruit.com/product/3678
+
+ // Re-connects to last connected device
+ audio.reconnect();
+
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;

--- a/examples/fullDRC/fullDRC.ino
+++ b/examples/fullDRC/fullDRC.ino
@@ -4,11 +4,20 @@ btAudio audio = btAudio("ESP_Speaker");
 String command;
 
 void setup() { 
+
+ // Streams audio data to the ESP32   
  audio.begin();
+
+ // Re-connects to last connected device
+ audio.reconnect();
+
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;
  audio.I2S(bck, dout, ws);
+
+ // Opens the serial port
  Serial.begin(115200);
 }
 

--- a/examples/highpassFilter/highpassFilter.ino
+++ b/examples/highpassFilter/highpassFilter.ino
@@ -4,14 +4,22 @@ btAudio audio = btAudio("ESP_Speaker");
 String command;
 
 void setup() { 
+
+ // Streams audio data to the ESP32   
  audio.begin();
+
+ // Re-connects to last connected device
+ audio.reconnect();
+
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;
  audio.I2S(bck, dout, ws);
+
+ // Opens the serial port
  Serial.begin(115200);
 }
-
 
 int fo=3;
 float fc=30;

--- a/examples/lowpassFilter/lowpassFilter.ino
+++ b/examples/lowpassFilter/lowpassFilter.ino
@@ -4,14 +4,22 @@ btAudio audio = btAudio("ESP_Speaker");
 String command;
 
 void setup() { 
+
+ // Streams audio data to the ESP32   
  audio.begin();
+
+ // Re-connects to last connected device
+ audio.reconnect();
+
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;
  audio.I2S(bck, dout, ws);
+
+ // Opens the serial port
  Serial.begin(115200);
 }
-
 
 int fo=3;
 float fc;

--- a/examples/minimalAudio/minimalAudio.ino
+++ b/examples/minimalAudio/minimalAudio.ino
@@ -5,10 +5,13 @@ btAudio audio = btAudio("ESP_Speaker");
 
 void setup() {
  
- // streams audio data to the ESP32   
+ // Streams audio data to the ESP32   
  audio.begin();
  
- //  outputs the received data to an I2S DAC https://www.adafruit.com/product/3678
+ // Re-connects to last connected device
+ audio.reconnect();
+ 
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;

--- a/examples/partialDRC/partialDRC.ino
+++ b/examples/partialDRC/partialDRC.ino
@@ -4,13 +4,21 @@ btAudio audio = btAudio("ESP_Speaker");
 String command;
 
 void setup() { 
+
+ // Streams audio data to the ESP32   
  audio.begin();
+
+ // Re-connects to last connected device
+ audio.reconnect();
+
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;
  audio.I2S(bck, dout, ws);
+
+ // Opens the serial port
  Serial.begin(115200);
- 
 }
 
 float thresh=30;

--- a/examples/queryMeta/queryMeta.ino
+++ b/examples/queryMeta/queryMeta.ino
@@ -4,16 +4,21 @@
 btAudio audio = btAudio("ESP_Speaker");
 
 void setup() {
- Serial.begin(115200);
- 
- // streams audio data to the ESP32   
+
+ // Streams audio data to the ESP32   
  audio.begin();
- 
- //  outputs the received data to an I2S DAC https://www.adafruit.com/product/3678
+
+ // Re-connects to last connected device
+ audio.reconnect();
+
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;
  audio.I2S(bck, dout, ws);
+
+ // Opens the serial port
+ Serial.begin(115200);
 }
 
 void loop() {

--- a/examples/serialControl/serialControl.ino
+++ b/examples/serialControl/serialControl.ino
@@ -4,12 +4,20 @@ btAudio audio = btAudio("ESP_Speaker");
 String command;
 
 void setup() { 
+
+ // Streams audio data to the ESP32   
  audio.begin();
+
+ // Re-connects to last connected device
+ audio.reconnect();
+
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
  int bck = 26; 
  int ws = 27;
  int dout = 25;
  audio.I2S(bck, dout, ws);
- // open the serial port
+
+ // Opens the serial port
  Serial.begin(115200);
 }
 

--- a/examples/webInterface/webInterface.ino
+++ b/examples/webInterface/webInterface.ino
@@ -8,21 +8,26 @@ btAudio audio = btAudio("ESP_Speaker");
 webDSP web;
 
 void setup() {
-  Serial.begin(115200);  
+
+ // Streams audio data to the ESP32   
+ audio.begin();
+
+ // Re-connects to last connected device
+ audio.reconnect();
+
+ // Outputs the received data to an I2S DAC, e.g. https://www.adafruit.com/product/3678
+ int bck = 26; 
+ int ws = 27;
+ int dout = 25;
+ audio.I2S(bck, dout, ws);
+
+ // Opens the serial port
+ Serial.begin(115200);
   
-  //start streaming audio
-  audio.begin();
-  
-  //transmit data to DAC
-  int bck = 26; 
-  int ws = 27;
-  int dout = 25;  
-  audio.I2S(bck, dout, ws);
-  
-  // replace ssid and password with your details
-  const char* ssid = "";
-  const char* password = "";
-  web.begin(ssid,password ,&audio); 
+ // Replace ssid and password with your details
+ const char* ssid = "";
+ const char* password = "";
+ web.begin(ssid, password, &audio); 
 }
 
 void loop() {

--- a/src/btAudio.cpp
+++ b/src/btAudio.cpp
@@ -59,7 +59,16 @@ void btAudio::begin() {
 #else
   esp_bt_gap_set_scan_mode(ESP_BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE);
 #endif
-  
+}
+
+void btAudio::end() {
+  esp_a2d_sink_deinit();
+  esp_bluedroid_disable();
+  esp_bluedroid_deinit();
+  btStop();
+}
+
+void btAudio::reconnect() {
   // Load rememebered device address from flash
   preferences.begin("btAudio", false);
   _address[0] = preferences.getUChar("btaddr0", 0);
@@ -84,19 +93,8 @@ void btAudio::begin() {
   }
 }
 
-void btAudio::end() {
-  esp_a2d_sink_deinit();
-  esp_bluedroid_disable();
-  esp_bluedroid_deinit();
-  btStop();
-}
-
 void btAudio::disconnect() {
   esp_a2d_sink_disconnect(_address);
-}
-
-void btAudio::reconnect() {
-  esp_a2d_sink_connect(_address);
 }
 
 void btAudio::a2d_cb(esp_a2d_cb_event_t event, esp_a2d_cb_param_t*param){
@@ -112,7 +110,7 @@ void btAudio::a2d_cb(esp_a2d_cb_event_t event, esp_a2d_cb_param_t*param){
 		    _address[4]= *(temp+4); _address[5]= *(temp+5);
             ESP_LOGI("btAudio", "Connected to BT device: %d %d %d %d %d %d", _address[0], _address[1], _address[2], _address[3], _address[4], _address[5]);
 
-		    // Store connected BT address to auto-connect on next init 
+		    // Store connected BT address for use by reconnect()
 		    preferences.begin("btAudio", false);
             if (preferences.getUChar("btaddr0", 0) != _address[0]) { preferences.putUChar("btaddr0", _address[0]); ESP_LOGI("btAudio", "Writing BTaddr0"); }
             if (preferences.getUChar("btaddr1", 0) != _address[1]) { preferences.putUChar("btaddr1", _address[1]); ESP_LOGI("btAudio", "Writing BTaddr1"); }

--- a/src/btAudio.cpp
+++ b/src/btAudio.cpp
@@ -1,9 +1,10 @@
 #include "btAudio.h"
+#include <Preferences.h> // For saving audio source BT addr for auto-reconnect
 ////////////////////////////////////////////////////////////////////
 ////////////// Nasty statics for i2sCallback ///////////////////////
 ////////////////////////////////////////////////////////////////////
  float btAudio::_vol=0.95;
- uint8_t btAudio::_address[6];
+ esp_bd_addr_t btAudio::_address;
  int32_t btAudio::_sampleRate=44100;
   
  String btAudio::title="";
@@ -18,6 +19,8 @@
  filter btAudio::_filtRlp = filter(20000,_sampleRate,3,lowpass);  
  DRC btAudio::_DRCL = DRC(_sampleRate,60.0,0.001,0.2,4.0,10.0,0.0); 
  DRC btAudio::_DRCR = DRC(_sampleRate,60.0,0.001,0.2,4.0,10.0,0.0); 
+ 
+ Preferences preferences;
 
 ////////////////////////////////////////////////////////////////////
 ////////////////////////// Constructor /////////////////////////////
@@ -34,10 +37,10 @@ void btAudio::begin() {
   //Arduino bluetooth initialisation
   btStart();
 
-  // bluedroid  allows for bluetooth classic
+  // bluedroid allows for bluetooth classic
   esp_bluedroid_init();
   esp_bluedroid_enable();
-   
+  
   //set up device name
   esp_bt_dev_set_device_name(_devName);
   
@@ -56,30 +59,73 @@ void btAudio::begin() {
 #else
   esp_bt_gap_set_scan_mode(ESP_BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE);
 #endif
-
+  
+  // Load rememebered device address from flash
+  preferences.begin("btAudio", false);
+  _address[0] = preferences.getUChar("btaddr0", 0);
+  _address[1] = preferences.getUChar("btaddr1", 0);
+  _address[2] = preferences.getUChar("btaddr2", 0);
+  _address[3] = preferences.getUChar("btaddr3", 0);
+  _address[4] = preferences.getUChar("btaddr4", 0);
+  _address[5] = preferences.getUChar("btaddr5", 0);
+  preferences.end();
+  
+  // Only attempt connection if address exists
+  if (_address[0] + _address[1] +
+      _address[2] + _address[3] +
+      _address[4] + _address[5] != 0)
+  {
+    ESP_LOGI("btAudio", "Connecting to remembered BT device: %d %d %d %d %d %d", 
+            _address[0], _address[1],
+            _address[2], _address[3],
+            _address[4], _address[5]);
+    // Connect to remembered device
+    esp_a2d_sink_connect(_address);
+  }
 }
+
 void btAudio::end() {
   esp_a2d_sink_deinit();
   esp_bluedroid_disable();
   esp_bluedroid_deinit();
-  btStop();  
+  btStop();
 }
+
+void btAudio::disconnect() {
+  esp_a2d_sink_disconnect(_address);
+}
+
+void btAudio::reconnect() {
+  esp_a2d_sink_connect(_address);
+}
+
 void btAudio::a2d_cb(esp_a2d_cb_event_t event, esp_a2d_cb_param_t*param){
 	esp_a2d_cb_param_t *a2d = (esp_a2d_cb_param_t *)(param);
 	switch (event) {
-    case ESP_A2D_CONNECTION_STATE_EVT:{
-        
+    case ESP_A2D_CONNECTION_STATE_EVT:
+    {
         uint8_t* temp= a2d->conn_stat.remote_bda;
-        _address[0]= *temp;
-		_address[1]= *(temp+1);
-		_address[2]= *(temp+2);
-		_address[3]= *(temp+3);
-		_address[4]= *(temp+4);
-		_address[5]= *(temp+5);    
-        break;
+        if (a2d->conn_stat.state == ESP_A2D_CONNECTION_STATE_CONNECTED)
+        {
+            _address[0]= *temp;     _address[1]= *(temp+1);
+		    _address[2]= *(temp+2); _address[3]= *(temp+3);
+		    _address[4]= *(temp+4); _address[5]= *(temp+5);
+            ESP_LOGI("btAudio", "Connected to BT device: %d %d %d %d %d %d", _address[0], _address[1], _address[2], _address[3], _address[4], _address[5]);
+
+		    // Store connected BT address to auto-connect on next init 
+		    preferences.begin("btAudio", false);
+            if (preferences.getUChar("btaddr0", 0) != _address[0]) { preferences.putUChar("btaddr0", _address[0]); ESP_LOGI("btAudio", "Writing BTaddr0"); }
+            if (preferences.getUChar("btaddr1", 0) != _address[1]) { preferences.putUChar("btaddr1", _address[1]); ESP_LOGI("btAudio", "Writing BTaddr1"); }
+            if (preferences.getUChar("btaddr2", 0) != _address[2]) { preferences.putUChar("btaddr2", _address[2]); ESP_LOGI("btAudio", "Writing BTaddr2"); }
+            if (preferences.getUChar("btaddr3", 0) != _address[3]) { preferences.putUChar("btaddr3", _address[3]); ESP_LOGI("btAudio", "Writing BTaddr3"); }
+            if (preferences.getUChar("btaddr4", 0) != _address[4]) { preferences.putUChar("btaddr4", _address[4]); ESP_LOGI("btAudio", "Writing BTaddr4"); }
+            if (preferences.getUChar("btaddr5", 0) != _address[5]) { preferences.putUChar("btaddr5", _address[5]); ESP_LOGI("btAudio", "Writing BTaddr5"); }
+            preferences.end();
+            break;
+        }
     }
 	case ESP_A2D_AUDIO_CFG_EVT: {
-        ESP_LOGI(BT_AV_TAG, "A2DP audio stream configuration, codec type %d", a2d->audio_cfg.mcc.type);
+        ESP_LOGI("BT_AV", "A2DP audio stream configuration, codec type %d", a2d->audio_cfg.mcc.type);
         // for now only SBC stream is supported
         if (a2d->audio_cfg.mcc.type == ESP_A2D_MCT_SBC) {
             _sampleRate = 16000;
@@ -91,13 +137,13 @@ void btAudio::a2d_cb(esp_a2d_cb_event_t event, esp_a2d_cb_param_t*param){
             } else if (oct0 & (0x01 << 4)) {
                 _sampleRate = 48000;
             }
-            ESP_LOGI(BT_AV_TAG, "Configure audio player %x-%x-%x-%x",
+            ESP_LOGI("BT_AV", "Configure audio player %x-%x-%x-%x",
                      a2d->audio_cfg.mcc.cie.sbc[0],
                      a2d->audio_cfg.mcc.cie.sbc[1],
                      a2d->audio_cfg.mcc.cie.sbc[2],
                      a2d->audio_cfg.mcc.cie.sbc[3]);
 					 if(i2s_set_sample_rates(I2S_NUM_0, _sampleRate)==ESP_OK){
-						ESP_LOGI(BT_AV_TAG, "Audio player configured, sample rate=%d", _sampleRate);
+						ESP_LOGI("BT_AV", "Audio player configured, sample rate=%d", _sampleRate);
 					 }
 		}
 		
@@ -149,7 +195,7 @@ void btAudio::avrc_callback(esp_avrc_ct_cb_event_t event, esp_avrc_ct_cb_param_t
       free(attr_text);
   }break;
     default:
-      ESP_LOGE(BT_RC_CT_TAG, "unhandled AVRC event: %d", event);
+      ESP_LOGE("RCCT", "unhandled AVRC event: %d", event);
       break;
   }
 }
@@ -337,4 +383,3 @@ void btAudio::decompress(){
 	 _postprocess = 0;
 	}
 }
-

--- a/src/btAudio.h
+++ b/src/btAudio.h
@@ -27,6 +27,8 @@ class btAudio {
 	// Bluetooth functionality
 	void begin();  
 	void end();
+	void disconnect();
+	void reconnect();
 	void setSinkCallback(void (*sinkCallback)(const uint8_t *data, uint32_t len));
 	
 	// I2S Audio


### PR DESCRIPTION
Stores the BT address in flash memory, so auto-connection can work across power cycles.  Only writes address to flash if it differs from the previously stored address, to avoid unnecessary flash wear.